### PR TITLE
Hotfix for bug discovered in getResults

### DIFF
--- a/src/ExactTargetLaravelApi.php
+++ b/src/ExactTargetLaravelApi.php
@@ -294,16 +294,14 @@ class ExactTargetLaravelApi implements ExactTargetLaravelInterface {
             }
             else {
                 $moreResults = [];
+                $moreResult[] = $results->results;
             }
 
 
             while ($results->moreResults)
             {
-                $moreResults[] = $this->fuelDe->GetMoreResults();
-                echo "more than 2500 results chunking";
-                echo "\n";
-                echo count($moreResults);
-                echo "\n";
+                $results = $this->fuelDe->getMoreResults();
+                $moreResults[] = $results->results;
             }
 
             return $moreResults;


### PR DESCRIPTION
Fixes the while loop that gets more results and builds an array.

Adds the first 2500 chunked results to the array. 